### PR TITLE
Fix Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,6 @@ before_install:
   - cp local.properties.ci local.properties
   - ls -all
   - source scripts/writeEnvVariables.sh && copyEnvVarsToManifest && copyEnvVarsToSigningProperties && copyEnvVarsToFastlaneConfiguration
-  - docker pull influxdb
-  - docker run --name=influxdb -d -p 127.0.0.1:8086:8086 influxdb
-  - docker ps -a
   - chmod +x ./gradlew
   - yes | sdkmanager "platforms;android-27"
 env:
@@ -47,7 +44,6 @@ android:
     - '.+'
 script:
   - android list target
-  - curl -i -XPOST http://127.0.0.1:8086/query --data-urlencode "q=CREATE DATABASE test"
   - ./gradlew clean test build
 before_deploy:
   - cd ${TRAVIS_BUILD_DIR}/app/build/outputs/apk/release && ls --all

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -297,6 +297,8 @@ dependencies {
 
     //
     implementation 'com.squareup:android-times-square:1.6.5@aar'
+
+    testCompile "org.testcontainers:testcontainers:1.12.3"
 }
 
 repositories {

--- a/app/src/test/java/science/apolline/InfluxDBServiceTest.kt
+++ b/app/src/test/java/science/apolline/InfluxDBServiceTest.kt
@@ -5,21 +5,31 @@ import com.google.gson.JsonObject
 import com.google.gson.JsonParser
 import org.junit.Assert
 import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
-import science.apolline.service.networks.*
-import science.apolline.models.Position
+import org.testcontainers.containers.wait.strategy.Wait
 import science.apolline.models.Device
+import science.apolline.models.Position
+import science.apolline.service.networks.ApiUtils
+import science.apolline.utils.GeoHashHelper
+import science.apolline.utils.InfluxDBContainer
 import science.apolline.utils.RequestParser
 import java.io.IOException
-import science.apolline.utils.GeoHashHelper
+
 
 /**
  * Created by sparow on 10/13/17.
  */
 
 class InfluxDBServiceTest {
+    companion object {
+        val INFLUXDB_DB = "test_db"
+        val INFLUXDB_USER = "test_user"
+        val INFLUXDB_USER_PASSWORD = "test_password"
+    }
 
-    private val testUrl = "http://localhost:8086/"
+    private var testUrl = "http://localhost:8086/"
     private var parser = JsonParser()
     private var JSONTOSEND = "{" +
             "\"CO2\":[100,\"PPM\"]," +
@@ -27,6 +37,24 @@ class InfluxDBServiceTest {
             "\"CH4\":[300,\"PPM\"]," +
             "\"O3\":[400,\"PPM\"]" +
             "}"
+
+    @Rule
+    @JvmField
+    val influxDBcontainer: InfluxDBContainer = InfluxDBContainer("influxdb:1.5.4")
+            .withEnv("INFLUXDB_DB",  INFLUXDB_DB)
+            .withEnv("INFLUXDB_USER", INFLUXDB_USER)
+            .withEnv("INFLUXDB_USER_PASSWORD", INFLUXDB_USER_PASSWORD)
+            .withExposedPorts(8086)
+            .waitingFor(Wait.forHttp("/ping").forStatusCode(204))
+
+    @Before
+    fun setUp() {
+        val containerIpAddress = influxDBcontainer.containerIpAddress
+        val firstMappedPort = influxDBcontainer.firstMappedPort
+
+        testUrl = String.format("http://%s:%s", containerIpAddress, firstMappedPort)
+    }
+
 
     /**
      * Test for input JSON parsing.
@@ -58,16 +86,16 @@ class InfluxDBServiceTest {
 
         val gson = Gson()
         val dataListObject = gson.fromJson(dataList, JsonObject::class.java)
-        val geohash = GeoHashHelper.encode(80.36,142.36)
+        val geohash = GeoHashHelper.encode(80.36, 142.36)
         val positionInitObject = Position("GPS", geohash, "Train")
-        val sensorInitObject = Device("ffffffff-c9cf-31db-0000-00006c125b14","Arduino", 1422568543702900257, positionInitObject, dataListObject,0)
+        val sensorInitObject = Device("ffffffff-c9cf-31db-0000-00006c125b14", "Arduino", 1422568543702900257, positionInitObject, dataListObject, 0)
 
         //when
         val dataTosend = RequestParser.createSingleRequestBody(sensorInitObject)
         println(dataTosend)
         ApiUtils.setUrl(testUrl)
         val api = ApiUtils.apiService
-        val call = api.savePost("test", "toto", "root", dataTosend)
+        val call = api.savePost(INFLUXDB_DB, INFLUXDB_USER, INFLUXDB_USER_PASSWORD, dataTosend)
         val response = call.execute()
 
         //then
@@ -78,9 +106,6 @@ class InfluxDBServiceTest {
     }
 
 }
-
-
-
 
 
 

--- a/app/src/test/java/science/apolline/utils/InfluxDBContainer.kt
+++ b/app/src/test/java/science/apolline/utils/InfluxDBContainer.kt
@@ -1,0 +1,5 @@
+package science.apolline.utils
+
+import org.testcontainers.containers.GenericContainer
+
+class InfluxDBContainer(imageName: String): GenericContainer<InfluxDBContainer>(imageName)


### PR DESCRIPTION
Programmatically start an influxdb container instead of using an external one. This allows us to wait for the database to be ready.

